### PR TITLE
JWT token 에서 권한 정보를 추출할 때 대괄호를 지우지 않았던 버그 수정 #3

### DIFF
--- a/src/main/java/com/nebula/nebula_resource/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/nebula/nebula_resource/config/security/SecurityConfiguration.java
@@ -76,7 +76,7 @@ public class SecurityConfiguration {
                 .csrf().disable()
                 .authorizeRequests()
                 .antMatchers("/admin/**","/actuator/**").hasAnyAuthority("ADMIN")
-                .anyRequest().hasAuthority("MEMBER")
+                .anyRequest().hasAnyAuthority("MEMBER")
                 //.anyRequest().permitAll()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/nebula/nebula_resource/helper/jwt/JwtUtil.java
+++ b/src/main/java/com/nebula/nebula_resource/helper/jwt/JwtUtil.java
@@ -50,7 +50,7 @@ public class JwtUtil {
         if(claims.get("roles")==null){
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");
         }
-        return Arrays.stream(claims.get("roles").toString().split(","))
+        return Arrays.stream(claims.get("roles").toString().replaceAll("[\\[\\[\\]]","").split(","))
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
JWT token 에서 권한 정보를 추출할 때 대괄호를 지우지 않았던 버그 수정

toString에서 권한정보리스트를 받아올 때 대괄호가 포함되어 있었음.